### PR TITLE
workflows: Run update_list.py, add auto-commit step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,3 +27,10 @@ jobs:
     - name: Validate files against schema
       run: |
         python validate.py
+    - name: Update formats.json
+      run: |
+        python update_list.py --add-errors
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Regenerated formats.json
+        file_pattern: formats.json


### PR DESCRIPTION
Extend the GH workflow to generate `formats.json` and commit it back.
Saves an extra manual step.

Branch with change "in action":
https://github.com/res2k/debatekeeper-formats/commits/workflow-experiment
- the "Apply automatic changes" commit was created by the change.