### PR TITLE
Add ASD Junior Championships format

### DIFF
--- a/v1/formats/asd-juniors.xml
+++ b/v1/formats/asd-juniors.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.2">
+  <name>Auckland Schools Junior Championships</name>
+  <short-name>ASD Juniors</short-name>
+  <version>1</version>
+  <info>
+    <region>Auckland</region>
+    <level>School</level>
+    <used-at>Auckland Schools Debating Junior Championships</used-at>
+    <description>3 vs 3, 5-minute speeches, 2.5-minute replies, no POIs</description>
+  </info>
+  <prep-time length="60:00"/>
+  <speech-types>
+    <speech-type ref="substantive" length="5:00" first-period="normal">
+      <bell time="4:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="reply" length="2:30" first-period="normal">
+      <bell time="1:30" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+  </speech-types>
+  <speeches>
+    <speech type="substantive">
+      <name>1st Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>1st Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Negative</name>
+    </speech>
+    <speech type="reply">
+      <name>Negative Leader's Reply</name>
+    </speech>
+    <speech type="reply">
+      <name>Affirmative Leader's Reply</name>
+    </speech>
+  </speeches>
+</debate-format>


### PR DESCRIPTION
If this is a debate format submission, please provide some information about the circuit, league or tournaments where this format is used:
- Auckland School Debating Junior Championships


By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
