### PR TITLE
Add ASD Impromptu format

### DIFF
--- a/v1/formats/asd-impromptu.xml
+++ b/v1/formats/asd-impromptu.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.2">
+  <name>Auckland Schools Impromptu</name>
+  <short-name>ASD Impromptu</short-name>
+  <version>1</version>
+  <info>
+    <region>New Zealand</region>
+    <level>School</level>
+    <used-at>Auckland Schools Debating Impromptu Cup</used-at>
+    <description>2 vs 2, 7 minutes prep, 5-minute substantive speeches, 2½-minute replies</description>
+  </info>
+  <period-types>
+    <period-type ref="easters.moot">
+      <name>Easters: Choose moot</name>
+      <display>Choose moot</display>
+    </period-type>
+    <period-type ref="easters.side">
+      <name>Easters: Choose side</name>
+      <display>Choose side</display>
+    </period-type>
+    <period-type ref="easters.prep">
+      <name>Easters: Prepare debate</name>
+      <display></display>
+    </period-type>
+  </period-types>
+  <prep-time-controlled length="7:00" first-period="easters.moot">
+    <bell time="1:00" number="1" pause-on-bell="true" next-period="easters.side"/>
+    <bell time="2:00" number="1" pause-on-bell="true" next-period="easters.prep"/>
+    <bell time="finish" number="2" next-period="overtime"/>
+  </prep-time-controlled>
+  <speech-types>
+    <speech-type ref="substantive" length="5:00" first-period="normal">
+      <bell time="4:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="reply" length="2:30" first-period="normal">
+      <bell time="1:30" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+  </speech-types>
+  <speeches>
+    <speech type="substantive">
+      <name>1st Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>1st Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Negative</name>
+    </speech>
+    <speech type="reply">
+      <name>Negative Leader's Reply</name>
+    </speech>
+    <speech type="reply">
+      <name>Affirmative Leader's Reply</name>
+    </speech>
+  </speeches>
+</debate-format>


### PR DESCRIPTION
If this is a debate format submission, please provide some information about the circuit, league or tournaments where this format is used:
- Auckland School Debating Impromptu Cup for year 10 to 13 students


By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
