### PR TITLE
`validate.py` now also checks whether the version number has been bumped

### DIFF
--- a/.github/workflows/update_list.yml
+++ b/.github/workflows/update_list.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install lxml pre-commit
+        pip install lxml pre-commit requests
 
     - name: Update formats.json
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install lxml pre-commit
+        pip install lxml pre-commit requests
 
     - name: Run lint checks
       run: |

--- a/validate.py
+++ b/validate.py
@@ -35,7 +35,7 @@ def validate_file(path):
     return errors
 
 
-def version_number_has_changed(path: Path, formats_list_path: Path = Path("v1/formats.json")) -> list[str]:
+def validate_version_number_has_changed(path: Path, formats_list_path: Path = Path("v1/formats.json")) -> list[str]:
     filename = path.name
     root = etree.parse(open(path))
 
@@ -69,7 +69,9 @@ def file_has_changed(path: Path, formats_list_path: Path = Path("v1/formats.json
         return True  # the fact it is not in formats.json yet means that it has been changed or is new
 
     # It feels somewhat hacky to get the old version this way but there doesn't seem to be an easy alternative
-    old_version = requests.get(old_url).text
+    response = requests.get(old_url)
+    response.encoding = "UTF-8"
+    old_version = response.text.replace("\r", "")
 
     return new_version != old_version
 

--- a/validate.py
+++ b/validate.py
@@ -39,6 +39,9 @@ def validate_file(path):
 
 
 def validate_version_number_has_changed(path: Path, formats_list_path: Path = Path("v1/formats.json")) -> list[str]:
+    """Checks if the version number in the file path has changed by comparing it to the version number in
+    formats_list_path. Only checks if the version number in the xml document is less than or equal to the number
+    in the json document, so already presumes that the file has been changed."""
     filename = path.name
     root = etree.parse(open(path))
 
@@ -59,6 +62,7 @@ def validate_version_number_has_changed(path: Path, formats_list_path: Path = Pa
 
 
 def file_has_changed(path: Path, formats_list_path: Path = Path("v1/formats.json")) -> bool:
+    """Detects whether the file path has been modified."""
     filename = path.name
     new_version = open(path).read()
 

--- a/validate.py
+++ b/validate.py
@@ -2,9 +2,10 @@
 """Validates debate format XML files against the schema."""
 
 import argparse
+import json
 import re
 from pathlib import Path
-import json
+
 import requests
 
 from lxml import etree

--- a/validate.py
+++ b/validate.py
@@ -32,6 +32,9 @@ def validate_file(path):
 
     errors = validate_cross_references(path.name, root)
     errors += validate_multilingual_elements(path.name, root)
+
+    if file_has_changed(path):
+        errors += validate_version_number_has_changed(path)
     return errors
 
 
@@ -49,7 +52,7 @@ def validate_version_number_has_changed(path: Path, formats_list_path: Path = Pa
             json_version_number = format["version"]
             break
 
-    if extracted_version_number == json_version_number:
+    if extracted_version_number <= json_version_number:
         return [f"Version number error in {filename}, version number has not changed."]
 
     return []


### PR DESCRIPTION
The check for the version number is only executed when a format file has actually changed. Before approving please have a look at `file_has_changed` as the implementation of change detection is a bit iffy as of now.

closes #14 