### PR TITLE
Check for version number bump using Git commands

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: ${{ github.event.pull_request.commits }}
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
@@ -38,7 +40,7 @@ jobs:
 
     - name: Validate XML files against schema
       run: |
-        python validate.py --git-base-ref=${{ github.base_ref }}
+        python validate.py --git-base-ref=${{ github.event.pull_request.base.sha }}
 
     # diff exits with 1 if differences, 2 if trouble; "|| [ $? -eq 1 ]" gets it to treat 1 as success
     - name: Dry run of updating formats.json

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Validate XML files against schema
       run: |
-        python validate.py
+        python validate.py --git-base-ref=${{ github.base_ref }}
 
     # diff exits with 1 if differences, 2 if trouble; "|| [ $? -eq 1 ]" gets it to treat 1 as success
     - name: Dry run of updating formats.json

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: ${{ github.event.pull_request.commits }}
+        fetch-depth: ${{ github.event.pull_request.commits || 0 }}
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
@@ -38,9 +38,15 @@ jobs:
       run: |
         pre-commit run --all-files
 
-    - name: Validate XML files against schema
+    - name: Validate XML files against schema (pull request)
+      if: github.event_name == 'pull_request'
       run: |
         python validate.py --git-base-ref=${{ github.event.pull_request.base.sha }}
+
+    - name: Validate XML files against schema (push)
+      if: github.event_name == 'push' && !github.event.forced
+      run: |
+        python validate.py --git-base-ref=${{ github.event.before }}
 
     # diff exits with 1 if differences, 2 if trouble; "|| [ $? -eq 1 ]" gets it to treat 1 as success
     - name: Dry run of updating formats.json

--- a/validate.py
+++ b/validate.py
@@ -5,6 +5,7 @@ import argparse
 import re
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 from lxml import etree
 
@@ -14,7 +15,7 @@ validator = etree.RelaxNG(etree.parse("schema-2.2.rng"))
 LANG_ATTR = "{http://www.w3.org/XML/1998/namespace}lang"
 
 
-def validate_file(path: Path, git_base_ref: str = None) -> list[str]:
+def validate_file(path: Path, git_base_ref: Optional[str] = None) -> list[str]:
     """Validates the file given by the path `path`, and returns a list of syntax, validation or
     cross-reference errors. (If validation is successful, the list will be empty.)"""
 
@@ -35,7 +36,7 @@ def validate_file(path: Path, git_base_ref: str = None) -> list[str]:
     return errors
 
 
-def validate_version_number(path: Path, git_base_ref: str = None) -> list[str]:
+def validate_version_number(path: Path, git_base_ref: Optional[str] = None) -> list[str]:
     """Validates that the version number in the file given by the path `path` has changed, by
     comparing it to the version number in the same file of the commit given by `git_base_ref`. The
     validation passes if no `git_base_ref` is given, or if the file has not changed."""
@@ -157,7 +158,7 @@ def validate_multilingual_element(filename: str, languages: list, element: etree
     return errors
 
 
-def validate_all_files(formats_dir: Path, git_base_ref: str = None) -> int:
+def validate_all_files(formats_dir: Path, git_base_ref: Optional[str] = None) -> int:
     """Validates all files in the directory `formats_dir`."""
     if not formats_dir.is_dir():
         print(f"{formats_dir} is not a directory")


### PR DESCRIPTION
This builds on and has the same objective as #16, except that it checks the version on the target branch of the PR (`github.base_ref`) using Git, rather than checking the published repository.

This way the comparison is the change made by the PR, which will normally be the same as the change relative to the current official repository, but if they ever differ I think we're trying to check the PR. This also (I think?) allows the PR to update formats.json itself, without making it look like the XML file's version number hasn't been updated.

I squashed the five commits in #16 down into one commit in this PR, as all five commits collectively form a single change.

@daankoning your opinions would be valued here! 🙂 

Closes #14

------------------------

By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
