### PR TITLE
Fetch entire repository in validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: ${{ github.event.pull_request.commits || 0 }}
+        fetch-depth: 0
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v2


### PR DESCRIPTION
We actually just want to go to the commit before the earliest commit in the pull request or push, but it's too hard to figure out in GitHub actions syntax, so just opt in to fetching everything.

---------------

By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
