### PR TITLE
Make the version number checking ignore new files

### DIFF
--- a/scripts/check_version_bump.py
+++ b/scripts/check_version_bump.py
@@ -41,6 +41,8 @@ def check_version_number_increment(path: Path, base_ref: str) -> list[str]:
     try:
         original_content = subprocess.check_output(["git", "show", f"{base_ref}:{path}"], stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
+        if e.returncode == 128:  # The file doesn't exist yet on the parent commit (i.e. the file is new in this PR)
+            return 0
         print(f"🛑 {filename} ERROR: Error getting original contents: {e}")
         return 1
 


### PR DESCRIPTION
Because `git show` exits with code 128 if the file isn't found in the commit it is sufficient to catch this and ignore it.

closes #20 

By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
