### PR TITLE
Check added files have version 1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,6 +62,9 @@ Some conventions in this repository are stricter than in the app.
 - **Human-readable names**, _e.g._ the style name and speech names:
   - should be in the grammatically appropriate case for that language
   - should prefer the technically "correct" name to the common colloquial name (if they differ)
+- **Version numbers**:
+  - should be 1 if it's a new format
+  - should increase when a format is updated (increments preferred)
 - **In [multilingual files](https://github.com/czlee/debatekeeper/wiki/Writing-your-own-custom-debate-format-file#multilingual-formats)**:
   - All languages must be declared in the `<languages>` element.
   - Every human-readable string must have a translation in all declared languages.


### PR DESCRIPTION
As discussed in #23. Checks that new files have version 1, and fails validation if any don't.

I thought about producing a warning without a nonzero exit code, but I won't see it unless it clearly shows as failed on the PR on GitHub. So it's just an error, and I can presumably just override it if I deem it ignorable.

------------------

By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
