### PR TITLE
Short version of Jugend Debattiert format

### DIFF
--- a/v1/formats/german-jugend-debattiert-6-minutes.xml
+++ b/v1/formats/german-jugend-debattiert-6-minutes.xml
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.2">
+    <name xml:lang="en">German Jugend Debattiert (6 minutes)</name>
+    <name xml:lang="de">Jugend Debattiert (6 Minuten)</name>
+    <short-name xml:lang="en">JD (6 minutes)</short-name>
+    <short-name xml:lang="de">JD (6 Minuten)</short-name>
+
+    <version>1</version>
+
+    <languages>
+        <language>de</language>
+        <language>en</language>
+    </languages>
+
+    <info xml:lang="de">
+        <region>Deutschland</region>
+        <level>Weiterführende Schulen</level>
+        <used-at>Jugend Debattiert Wettbewerb</used-at>
+        <description>Zwei Zweierteams, Eröffnungsreden (jeweils 2 Minuten) + freie Aussprache (6 Minuten) + Schlussreden (jeweils 1 Minute)</description>
+    </info>
+    <info xml:lang="en">
+        <region>Germany</region>
+        <level>Secondary schools</level>
+        <used-at>Jugend Debattiert Competition</used-at>
+        <description>Two teams of two, opening speeches (2 minutes each) + free debate (6 minutes) + closing speeches (1 minute each)</description>
+    </info>
+
+    <period-types>
+        <period-type ref="jd.opening-speech">
+            <name xml:lang="de">JD: Eröffnungsrede</name>
+            <name xml:lang="en">JD: Opening speech</name>
+            <display xml:lang="de">Eröffnungsrede</display>
+            <display xml:lang="en">Opening speech</display>
+        </period-type>
+        <period-type ref="jd.closing-speech">
+            <name xml:lang="de">JD: Schlussrede</name>
+            <name xml:lang="en">JD: Closing speech</name>
+            <display xml:lang="de">Schlussrede</display>
+            <display xml:lang="en">Closing speech</display>
+        </period-type>
+    </period-types>
+
+    <speech-types>
+        <speech-type ref="opening" length="2:00" first-period="jd.opening-speech">
+            <name xml:lang="en">Opening speech</name>
+            <name xml:lang="de">Eröffnungsrede</name>
+            <bell time="1:45" number="1" next-period="warning"/>
+            <bell time="finish" number="2" next-period="overtime"/>
+        </speech-type>
+        <speech-type ref="exchange" length="6:00" first-period="normal">
+            <name xml:lang="en">Free debate</name>
+            <name xml:lang="de">Freie Aussprache</name>
+            <bell time="5:45" number="1" next-period="warning"/>
+            <bell time="finish" number="2" next-period="overtime"/>
+        </speech-type>
+        <speech-type ref="closing" length="1:00" first-period="jd.closing-speech">
+            <name xml:lang="en">Closing speech</name>
+            <name xml:lang="de">Schlussrede</name>
+            <bell time="0:45" number="1" next-period="warning"/>
+            <bell time="finish" number="2" next-period="overtime"/>
+        </speech-type>
+    </speech-types>
+
+    <speeches>
+
+        <speech type="opening">
+            <name xml:lang="de">Pro 1</name>
+            <name xml:lang="en">Pro 1</name>
+        </speech>
+        <speech type="opening">
+            <name xml:lang="de">Kontra 1</name>
+            <name xml:lang="en">Contra 1</name>
+        </speech>
+        <speech type="opening">
+            <name xml:lang="de">Pro 2</name>
+            <name xml:lang="en">Pro 2</name>
+        </speech>
+        <speech type="opening">
+            <name xml:lang="de">Kontra 2</name>
+            <name xml:lang="en">Contra 2</name>
+        </speech>
+
+        <speech type="exchange">
+            <name xml:lang="de">Freie Aussprache</name>
+            <name xml:lang="en">Free debate</name>
+        </speech>
+
+        <speech type="closing">
+            <name xml:lang="de">Pro 1</name>
+            <name xml:lang="en">Pro 1</name>
+        </speech>
+        <speech type="closing">
+            <name xml:lang="de">Kontra 1</name>
+            <name xml:lang="en">Contra 1</name>
+        </speech>
+        <speech type="closing">
+            <name xml:lang="de">Pro 2</name>
+            <name xml:lang="en">Pro 2</name>
+        </speech>
+        <speech type="closing">
+            <name xml:lang="de">Kontra 2</name>
+            <name xml:lang="en">Contra 2</name>
+        </speech>
+    </speeches>
+
+</debate-format>


### PR DESCRIPTION
In Addition to the recently added standard Jugend Debattiert format, here is the same with some little tweaks to the duration, for shorter debates.

By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
