### PR TITLE
Add Auckland Schools Debate Formats

### DIFF
--- a/v1/formats/asd-openjunior.xml
+++ b/v1/formats/asd-openjunior.xml
@@ -4,11 +4,12 @@
   <short-name>ASD Junior Open</short-name>
   <version>1</version>
   <info>
-    <region>New Zealand</region>
+    <region>Auckland</region>
     <level>School</level>
     <used-at>Auckland Schools Debating Junior Open Competitions</used-at>
     <description>3 vs 3, 5-minute speeches, 2½-minute replies, no POIs</description>
   </info>
+  <prep-time length="60:00"/>
   <speech-types>
     <speech-type ref="substantive" length="5:00" first-period="normal">
       <bell time="4:00" number="1" next-period="warning"/>

--- a/v1/formats/asd-openjunior.xml
+++ b/v1/formats/asd-openjunior.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.2">
+  <name>ASD Junior Open</name>
+  <version>1</version>
+  <info>
+    <region>New Zealand</region>
+    <level>School</level>
+    <used-at>Auckland Schools Debating Junior Open Competitions</used-at>
+    <description>3 vs 3, 5-minute speeches, 2.5-minute replies, no POIs</description>
+  </info>
+  <speech-types>
+    <speech-type ref="substantive" length="5:00" first-period="normal">
+      <bell time="4:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="reply" length="2:30" first-period="normal">
+      <bell time="1:30" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+  </speech-types>
+  <speeches>
+    <speech type="substantive">
+      <name>1st Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>1st Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Negative</name>
+    </speech>
+    <speech type="reply">
+      <name>Negative Reply</name>
+    </speech>
+    <speech type="reply">
+      <name>Affirmative Reply</name>
+    </speech>
+  </speeches>
+</debate-format>

--- a/v1/formats/asd-openjunior.xml
+++ b/v1/formats/asd-openjunior.xml
@@ -1,12 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <debate-format schema-version="2.2">
-  <name>ASD Junior Open</name>
+  <name>Auckland Schools Junior Open</name>
+  <short-name>ASD Junior Open</short-name>
   <version>1</version>
   <info>
     <region>New Zealand</region>
     <level>School</level>
     <used-at>Auckland Schools Debating Junior Open Competitions</used-at>
-    <description>3 vs 3, 5-minute speeches, 2.5-minute replies, no POIs</description>
+    <description>3 vs 3, 5-minute speeches, 2½-minute replies, no POIs</description>
   </info>
   <speech-types>
     <speech-type ref="substantive" length="5:00" first-period="normal">

--- a/v1/formats/asd-opensenior.xml
+++ b/v1/formats/asd-opensenior.xml
@@ -4,7 +4,7 @@
   <short-name>ASD Senior Open</short-name>
   <version>1</version>
   <info>
-    <region>New Zealand</region>
+    <region>Auckland</region>
     <level>School</level>
     <used-at>Auckland Schools Debating Senior Open Competitions</used-at>
     <description>3 vs 3, 6-minute speeches, 3-minute replies, no POIs</description>

--- a/v1/formats/asd-opensenior.xml
+++ b/v1/formats/asd-opensenior.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.2">
+  <name>ASD Senior Open</name>
+  <version>1</version>
+  <info>
+    <region>New Zealand</region>
+    <level>School</level>
+    <used-at>Auckland Schools Debating Senior Open Competitions</used-at>
+    <description>3 vs 3, 6-minute speeches, 3-minute replies, no POIs</description>
+  </info>
+  <prep-time length="60:00"/>
+  <speech-types>
+    <speech-type ref="substantive" length="6:00" first-period="normal">
+      <bell time="1:00" number="1" next-period="normal"/>
+      <bell time="5:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="reply" length="3:00" first-period="normal">
+      <bell time="2:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+  </speech-types>
+  <speeches>
+    <speech type="substantive">
+      <name>1st Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>1st Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Negative</name>
+    </speech>
+    <speech type="reply">
+      <name>Negative Reply</name>
+    </speech>
+    <speech type="reply">
+      <name>Affirmative Reply</name>
+    </speech>
+  </speeches>
+</debate-format>

--- a/v1/formats/asd-opensenior.xml
+++ b/v1/formats/asd-opensenior.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <debate-format schema-version="2.2">
-  <name>ASD Senior Open</name>
+  <name>Auckland Schools Senior Open</name>
+  <short-name>ASD Senior Open</short-name>
   <version>1</version>
   <info>
     <region>New Zealand</region>

--- a/v1/formats/asd-opensenior.xml
+++ b/v1/formats/asd-opensenior.xml
@@ -11,7 +11,6 @@
   <prep-time length="60:00"/>
   <speech-types>
     <speech-type ref="substantive" length="6:00" first-period="normal">
-      <bell time="1:00" number="1" next-period="normal"/>
       <bell time="5:00" number="1" next-period="warning"/>
       <bell time="finish" number="2" next-period="overtime"/>
     </speech-type>

--- a/v1/formats/asd-premjunior.xml
+++ b/v1/formats/asd-premjunior.xml
@@ -4,7 +4,7 @@
   <short-name>ASD Premier Junior</short-name>
   <version>1</version>
   <info>
-    <region>New Zealand</region>
+    <region>Auckland</region>
     <level>School</level>
     <used-at>Auckland Schools Debating Premier Junior Competitions</used-at>
     <description>3 vs 3, 6-minute speeches, 3-minute replies, POIs allowed</description>

--- a/v1/formats/asd-premjunior.xml
+++ b/v1/formats/asd-premjunior.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.2">
+  <name>ASD Premier Junior</name>
+  <version>1</version>
+  <info>
+    <region>New Zealand</region>
+    <level>School</level>
+    <used-at>Auckland Schools Debating Premier Junior Competitions</used-at>
+    <description>3 vs 3, 6-minute speeches, 3-minute replies, POIs allowed</description>
+  </info>
+  <prep-time length="60:00"/>
+  <speech-types>
+    <speech-type ref="substantive" length="6:00" first-period="normal">
+      <bell time="1:00" number="1" next-period="pois-allowed"/>
+      <bell time="5:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="reply" length="3:00" first-period="normal">
+      <bell time="2:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+  </speech-types>
+  <speeches>
+    <speech type="substantive">
+      <name>1st Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>1st Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>2nd Negative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Affirmative</name>
+    </speech>
+    <speech type="substantive">
+      <name>3rd Negative</name>
+    </speech>
+    <speech type="reply">
+      <name>Negative Reply</name>
+    </speech>
+    <speech type="reply">
+      <name>Affirmative Reply</name>
+    </speech>
+  </speeches>
+</debate-format>

--- a/v1/formats/asd-premjunior.xml
+++ b/v1/formats/asd-premjunior.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <debate-format schema-version="2.2">
-  <name>ASD Premier Junior</name>
+  <name>Auckland Schools Premier Junior</name>
+  <short-name>ASD Premier Junior</short-name>
   <version>1</version>
   <info>
     <region>New Zealand</region>


### PR DESCRIPTION
If this is a debate format submission, please provide some information about the circuit, league or tournaments where this format is used:
Auckland Schools Debating (Prem Junior, Junior Open, Senior Open events)

Closes #2 .

By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
