### PR TITLE
Update archdale-juniors.xml

### DIFF
--- a/v1/formats/archdale-juniors.xml
+++ b/v1/formats/archdale-juniors.xml
@@ -7,7 +7,7 @@
     <region>NSW, Australia</region>
     <level>Years 7-9</level>
     <used-at>IGSA Archdale Debating Competition</used-at>
-    <description>3 vs 3, 7-minute speeches, no replies, no POIs</description>
+    <description>3 vs 3, 6-minute speeches, no replies, no POIs</description>
   </info>
   <period-types>
     <period-type ref="nsw.1bell">
@@ -17,9 +17,9 @@
   </period-types>
   <prep-time length="45:00"/>
   <speech-types>
-    <speech-type ref="speech" length="7:30" first-period="normal">
-      <bell time="5:00" number="1" next-period="nsw.1bell"/>
-      <bell time="7:00" number="2" next-period="warning"/>
+    <speech-type ref="speech" length="6:30" first-period="normal">
+      <bell time="4:00" number="1" next-period="nsw.1bell"/>
+      <bell time="6:00" number="2" next-period="warning"/>
       <bell time="finish" number="30" next-period="overtime"/>
     </speech-type>
   </speech-types>

--- a/v1/formats/archdale-juniors.xml
+++ b/v1/formats/archdale-juniors.xml
@@ -2,7 +2,7 @@
 <debate-format schema-version="2.2">
   <name>IGSA Archdale Debating Competition ('Juniors')</name>
   <short-name>Archdale 'Juniors'</short-name>
-  <version>1</version>
+  <version>2</version>
   <info>
     <region>NSW, Australia</region>
     <level>Years 7-9</level>


### PR DESCRIPTION
Updating bell times in line with the 2026 Archdale Ops Manual.

If this is a debate format submission, please provide some information about the circuit, league or tournaments where this format is used:

The 2026 Ops Manual for the Archdale Invitational competition shortened the times for the Seniors and Inters divisions.



By submitting this pull request, I agree to license my contributions under the [MIT License](https://github.com/czlee/debatekeeper-formats/blob/main/LICENCE.md).
